### PR TITLE
Add phash-changer Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,57 @@
+import os
+import uuid
+from flask import (
+    Flask,
+    request,
+    redirect,
+    url_for,
+    render_template,
+    send_from_directory,
+)
+from PIL import Image
+
+from phash_mutator import generate_variants, phash
+
+app = Flask(__name__)
+
+TEMP_DIR = "/tmp"
+
+
+@app.route("/")
+def index():
+    """Render simple upload form."""
+    return render_template("index.html")
+
+
+@app.route("/mutate", methods=["POST"])
+def mutate():
+    """Handle upload and display variant results."""
+    file = request.files.get("image")
+    if not file or file.filename == "":
+        return redirect(url_for("index"))
+
+    ext = os.path.splitext(file.filename)[1] or ".png"
+    orig_name = f"orig_{uuid.uuid4().hex}{ext}"
+    path_in = os.path.join(TEMP_DIR, orig_name)
+    file.save(path_in)
+
+    variants = generate_variants(path_in, n=10)
+
+    orig_hash = phash(Image.open(path_in).convert("RGB"))
+
+    return render_template(
+        "result.html",
+        orig_path=orig_name,
+        orig_hash=str(orig_hash),
+        variants=variants,
+    )
+
+
+@app.route("/tmp/<path:filename>")
+def temp_files(filename):
+    """Serve files saved in the temporary directory."""
+    return send_from_directory(TEMP_DIR, filename)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/phash_mutator.py
+++ b/phash_mutator.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from typing import List, Dict
+import uuid
+import random
+import numpy as np
+from PIL import Image, ImageEnhance
+import imagehash
+from utils import hamming
+
+
+def phash(img: Image.Image) -> imagehash.ImageHash:
+    """Return perceptual hash of the image."""
+    return imagehash.phash(img)
+
+
+_TRANSFORMS = (
+    "tiny_crop",
+    "brightness",
+    "gaussian_noise",
+    "shift_one_pixel",
+)
+
+
+def random_transform(img: Image.Image, op: str) -> Image.Image:
+    """Return a new Image after applying one micro-edit."""
+    if op == "tiny_crop":
+        # crop 1-2 pixels around the border then resize back
+        w, h = img.size
+        left = random.randint(0, 2)
+        top = random.randint(0, 2)
+        right = random.randint(0, 2)
+        bottom = random.randint(0, 2)
+        cropped = img.crop((left, top, w - right, h - bottom))
+        return cropped.resize((w, h))
+    if op == "brightness":
+        factor = 1 + random.uniform(-0.1, 0.1)
+        enhancer = ImageEnhance.Brightness(img)
+        return enhancer.enhance(factor)
+    if op == "gaussian_noise":
+        arr = np.array(img).astype(np.float32)
+        noise = np.random.normal(0, 3, arr.shape)
+        arr += noise
+        arr = np.clip(arr, 0, 255).astype(np.uint8)
+        return Image.fromarray(arr)
+    if op == "shift_one_pixel":
+        arr = np.array(img)
+        dx = random.choice([-1, 1])
+        dy = random.choice([-1, 1])
+        arr = np.roll(arr, shift=dx, axis=1)
+        arr = np.roll(arr, shift=dy, axis=0)
+        return Image.fromarray(arr)
+    raise ValueError(f"Unknown transform: {op}")
+
+
+def mutate_once(img: Image.Image):
+    """Apply one random_transform picked from _TRANSFORMS."""
+    op = random.choice(_TRANSFORMS)
+    return random_transform(img, op), op
+
+
+def generate_variants(
+    path_in: str,
+    n: int = 10,
+    target_bits: int = 14,
+    inter_bits: int = 6,
+    max_iter: int = 300,
+) -> List[Dict]:
+    """Return list of unique variants meeting distance constraints."""
+    orig = Image.open(path_in).convert("RGB")
+    h0 = phash(orig)
+    variants = []
+    iter_cnt = 0
+    while len(variants) < n and iter_cnt < max_iter:
+        iter_cnt += 1
+        img_tmp = orig.copy()
+        ops = []
+        for _ in range(3):
+            img_tmp, op = mutate_once(img_tmp)
+            ops.append(op)
+        h1 = phash(img_tmp)
+        d0 = hamming(h0, h1)
+        if d0 < target_bits:
+            continue
+        if any(hamming(v["phash_int"], h1) < inter_bits for v in variants):
+            continue
+        out_path = f"/tmp/mut_{uuid.uuid4().hex}.png"
+        img_tmp.save(out_path, "PNG")
+        variants.append(
+            dict(
+                path_out=out_path,
+                phash_int=int(str(h1), 16),
+                distance_to_original=d0,
+                ops_history=ops,
+            )
+        )
+    if len(variants) < n:
+        raise RuntimeError(
+            f"Generated only {len(variants)} variants after {iter_cnt} attempts."
+        )
+    return variants

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>pHash Changer</title>
+</head>
+<body>
+  <h1>Upload Image</h1>
+  <form action="{{ url_for('mutate') }}" method="post" enctype="multipart/form-data">
+    <input type="file" name="image" accept="image/*" required>
+    <button type="submit">Submit</button>
+  </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Results</title>
+  <style>
+    table, th, td {border: 1px solid #aaa; border-collapse: collapse; padding: 4px;}
+    img {max-width: 100px;}
+  </style>
+</head>
+<body>
+<h1>Mutation Results</h1>
+<section>
+  <h2>Original</h2>
+  <p>pHash: {{ orig_hash }}</p>
+  <img src="{{ url_for('temp_files', filename=orig_path) }}" alt="original">
+</section>
+
+<h2>Variants</h2>
+<table>
+  <tr><th>Image</th><th>pHash</th><th>Dist to Original</th></tr>
+  {% for v in variants %}
+  <tr>
+    <td><img src="{{ url_for('temp_files', filename=v.path_out.split('/')[-1]) }}" alt="variant"></td>
+    <td>{{ '%016x' % v.phash_int }}</td>
+    <td>{{ v.distance_to_original }}</td>
+  </tr>
+  {% endfor %}
+</table>
+</body>
+</html>

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,13 @@
+from typing import Union
+import imagehash
+
+
+def hamming(
+    a: Union[int, imagehash.ImageHash], b: Union[int, imagehash.ImageHash]
+) -> int:
+    """Return Hamming distance between two 64-bit hashes."""
+    if not isinstance(a, int):
+        a = int(str(a), 16)
+    if not isinstance(b, int):
+        b = int(str(b), 16)
+    return bin(a ^ b).count("1")


### PR DESCRIPTION
## Summary
- add Flask app with upload form and mutation route
- implement pHash variant generator
- include utility function for hamming distance
- create basic HTML templates for uploading and viewing results
- format Python files for PEP-8 compliance

## Testing
- `python3 -m py_compile app.py phash_mutator.py utils.py`
- `pip install pillow numpy flask imagehash` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6883d4b157a883279caa8c447b3e7f5d